### PR TITLE
Read me 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Please add below pom dependency for rabbitmq-advanced-spring-boot-starter
     <dependency>
         <groupId>com.societegenerale</groupId>
         <artifactId>rabbitmq-advanced-spring-boot-starter</artifactId>
-        <version>1.0.1.RELEASE</version>
+        <version>2.0.0.RELEASE</version>
         <!-- check the latest version -->
     </dependency>
 ```
 
 ### Spring RabbitMQ Configuration
 
-Below is the sample spring rabbitmq configuration.`
+Below is the sample spring rabbitmq configuration.
 
 ```yaml
 spring:
@@ -62,10 +62,11 @@ spring:
     ssl:
       enabled: false
     listener:
-      default-requeue-rejected: false
-      retry:
-        enabled: true
-      acknowledge-mode: auto
+      simple:
+        default-requeue-rejected: false
+        retry:
+          enabled: true
+        acknowledge-mode: auto
 ```
 
 ### RabbitMQ Auto Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale</groupId>
     <artifactId>rabbitmq-advanced-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0.RELEASE</version>
     <packaging>pom</packaging>
 
     <name>rabbitmq-advanced-parent</name>
@@ -53,7 +53,7 @@
         <url>https://github.com/societe-generale/rabbitmq-advanced-spring-boot-starter</url>
         <connection>scm:git:git@github.com:societe-generale/rabbitmq-advanced-spring-boot-starter.git</connection>
         <developerConnection>scm:git:git@github.com:societe-generale/rabbitmq-advanced-spring-boot-starter.git</developerConnection>
-        <tag>rabbitmq_advanced_spring_boot_starter_1.0.0.RELEASE</tag>
+        <tag>rabbitmq_advanced_spring_boot_starter_2.0.0.RELEASE</tag>
     </scm>
 
     <distributionManagement>
@@ -185,7 +185,7 @@
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/rabbitmq-advanced-core/pom.xml
+++ b/rabbitmq-advanced-core/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale</groupId>
     <artifactId>rabbitmq-advanced-core</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0.RELEASE</version>
     <packaging>jar</packaging>
 
     <name>rabbitmq-advanced-core</name>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.societegenerale</groupId>
         <artifactId>rabbitmq-advanced-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0.RELEASE</version>
     </parent>
 
     <properties>

--- a/rabbitmq-advanced-spring-boot-autoconfigure/pom.xml
+++ b/rabbitmq-advanced-spring-boot-autoconfigure/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale</groupId>
     <artifactId>rabbitmq-advanced-spring-boot-autoconfigure</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0.RELEASE</version>
     <packaging>jar</packaging>
 
     <name>rabbitmq-advanced-spring-boot-autoconfigure</name>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.societegenerale</groupId>
         <artifactId>rabbitmq-advanced-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0.RELEASE</version>
     </parent>
 
     <properties>

--- a/rabbitmq-advanced-spring-boot-starter/pom.xml
+++ b/rabbitmq-advanced-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale</groupId>
     <artifactId>rabbitmq-advanced-spring-boot-starter</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0.RELEASE</version>
     <packaging>jar</packaging>
 
     <name>rabbitmq-advanced-spring-boot-starter</name>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.societegenerale</groupId>
         <artifactId>rabbitmq-advanced-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0.RELEASE</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## Release 2.0.0 version 

This release includes spring boot upgradation from spring boot 1.x.x to 2.x.x

## Details

Spring Boot Upgradation to 2.x.x.
Tracer fix for better traceability with new sleuth 
pom updates for release
Read Me update for release 

## Context

Why is this change required?  This release support new spring boot versions (2.x.x)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
https://github.com/societe-generale/rabbitmq-advanced-spring-boot-starter/issues/11