### PR TITLE
info header fix for addition additional info to message headers

### DIFF
--- a/rabbitmq-advanced-spring-boot-autoconfigure/src/main/java/com/societegenerale/commons/amqp/auto/configuration/RabbitMqConfiguration.java
+++ b/rabbitmq-advanced-spring-boot-autoconfigure/src/main/java/com/societegenerale/commons/amqp/auto/configuration/RabbitMqConfiguration.java
@@ -27,9 +27,9 @@ import com.societegenerale.commons.amqp.core.requeue.ReQueueConsumer;
 import com.societegenerale.commons.amqp.core.requeue.policy.ReQueuePolicy;
 import com.societegenerale.commons.amqp.core.requeue.policy.impl.ThresholdReQueuePolicy;
 import org.springframework.amqp.core.MessagePostProcessor;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.CorrelationDataPostProcessor;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -106,8 +106,8 @@ public class RabbitMqConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(RabbitAdmin.class)
-  public RabbitAdmin rabbitAdmin(ConnectionFactory connectionFactory) {
-    return new RabbitAdmin(connectionFactory);
+  public RabbitAdmin rabbitAdmin(RabbitTemplate rabbitTemplate) {
+    return new RabbitAdmin(rabbitTemplate);
   }
 
 }


### PR DESCRIPTION
## Summary

Bug fix for including additional info headers to message headers.
 
## Details

This will fix the issue by addition additional infos back to message headers.

## Context

Impacted environment is version 2.0.0.RELEASE
 
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
https://github.com/societe-generale/rabbitmq-advanced-spring-boot-starter/issues/15